### PR TITLE
fix: close receive flows on connection close

### DIFF
--- a/src/receive_flow.rs
+++ b/src/receive_flow.rs
@@ -11,13 +11,13 @@ use webrtc_util::Unmarshal;
 pub struct ReceiveFlow {
     id: VarInt,
     cancel_token: CancellationToken,
-    datagram_receiver: mpsc::Receiver<Bytes>,
+    datagram_receiver: mpsc::Receiver<Option<Bytes>>,
 }
 
 impl ReceiveFlow {
     pub(crate) fn new(
         id: VarInt,
-        receiver: mpsc::Receiver<Bytes>,
+        receiver: mpsc::Receiver<Option<Bytes>>,
         cancel_token: CancellationToken,
     ) -> Self {
         Self {
@@ -35,7 +35,7 @@ impl ReceiveFlow {
     /// Reads the next available RTP packet.
     pub async fn read_rtp(&mut self) -> Result<RtpPacket> {
         ensure!(!self.cancel_token.is_cancelled(), "closed");
-        let Some(mut bytes) = self.datagram_receiver.recv().await else {
+        let Some(Some(mut bytes)) = self.datagram_receiver.recv().await else {
             return Err(anyhow::anyhow!("session is closed"));
         };
 


### PR DESCRIPTION
Currently, receive flows are not closed once the connection closes, but only once the session is dropped. This changes this so that receive flows are closed once the connection closes.

Misses a test still (but I have one in callme).

Not super sold on how to do this. Might be even better to pass the error along, would need to add an error type that wraps ConnectionError for that I think.